### PR TITLE
Update gem to 3.9

### DIFF
--- a/app/controllers/concerns/the_role/controller.rb
+++ b/app/controllers/concerns/the_role/controller.rb
@@ -48,7 +48,7 @@ module TheRole
       else
         # When the user paste non authorized URL in browser the REFERER is blank and application crash
         if request.env["HTTP_REFERER"].present? and request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
-          redirect_to :back, flash: { error: access_denied_msg }
+          redirect_back fallback_location: root_path, flash: { error: access_denied_msg }
         else
           redirect_to root_path, flash: { error: access_denied_msg }
         end

--- a/app/models/_templates_/role.rb
+++ b/app/models/_templates_/role.rb
@@ -1,3 +1,3 @@
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   include TheRole::Api::Role
 end

--- a/config/initializers/the_role.rb
+++ b/config/initializers/the_role.rb
@@ -6,6 +6,7 @@ TheRole.configure do |config|
 
   # layout for Management panel
   # config.layout = :the_role_management_panel
+  # config.layout_title = 'The Role Gem'
 
   # config.default_user_role          = nil
   # config.first_user_should_be_admin = false

--- a/config/locales/en.the_role.yml
+++ b/config/locales/en.the_role.yml
@@ -1,3 +1,0 @@
-en:
-  the_role:
-    access_denied: "Access Denied"

--- a/config/locales/fr.the_role.yml
+++ b/config/locales/fr.the_role.yml
@@ -1,0 +1,3 @@
+en:
+  the_role:
+    access_denied: "Accès refusé"

--- a/config/locales/fr.the_role.yml
+++ b/config/locales/fr.the_role.yml
@@ -1,3 +1,3 @@
-en:
+fr:
   the_role:
     access_denied: "Accès refusé"

--- a/config/locales/hindi.the_role.yml
+++ b/config/locales/hindi.the_role.yml
@@ -1,0 +1,3 @@
+hindi:
+  the_role:
+    access_denied: "पहुंच अस्वीकृत"

--- a/db/migrate/20111025025129_create_roles.rb
+++ b/db/migrate/20111025025129_create_roles.rb
@@ -1,4 +1,4 @@
-class CreateRoles < ActiveRecord::Migration
+class CreateRoles < ActiveRecord::Migration[5.2]
   def self.up
     create_table :roles do |t|
       t.string :name,        null: false

--- a/gem_version.rb
+++ b/gem_version.rb
@@ -1,3 +1,0 @@
-module TheRoleApi
-  VERSION = "3.7"
-end

--- a/gem_version.rb
+++ b/gem_version.rb
@@ -1,3 +1,3 @@
 module TheRoleApi
-  VERSION = "3.6"
+  VERSION = "3.7"
 end

--- a/gem_version.rb
+++ b/gem_version.rb
@@ -1,3 +1,3 @@
 module TheRoleApi
-  VERSION = "3.0.3"
+  VERSION = "3.5"
 end

--- a/gem_version.rb
+++ b/gem_version.rb
@@ -1,3 +1,3 @@
 module TheRoleApi
-  VERSION = "3.5"
+  VERSION = "3.6"
 end

--- a/lib/the_role_api.rb
+++ b/lib/the_role_api.rb
@@ -30,15 +30,9 @@ module TheRole
       %w[ base_methods role user ].each do |file|
         require_dependency "#{ app }/models/concerns/the_role/api/#{ file }.rb"
       end
-    end
-
-    if Rails::VERSION::MAJOR == 4
+    else
       config.autoload_paths << "#{ config.root }/app/models/concerns/**"
       config.autoload_paths << "#{ config.root }/app/controllers/concerns/**"
-    end
-
-    if Rails::VERSION::MAJOR == 5
-      raise Exception.new("TheRole 3. Version for Rails 5 not tested yet")
     end
 
     initializer "the_role_precompile_hook", group: :all do |app|

--- a/lib/the_role_api.rb
+++ b/lib/the_role_api.rb
@@ -1,6 +1,5 @@
 require 'the_role_api/hash'
 require 'the_role_api/config'
-require 'the_role_api/version'
 
 require 'multi_json'
 require 'the_string_to_slug'

--- a/lib/the_role_api/config.rb
+++ b/lib/the_role_api/config.rb
@@ -11,6 +11,7 @@ module TheRole
   class Configuration
     include ActiveSupport::Configurable
     config_accessor :layout,
+                    :layout_title,
                     :destroy_strategy,
                     :default_user_role,
                     :access_denied_method,
@@ -20,6 +21,7 @@ module TheRole
 
   configure do |config|
     config.layout = :application
+    config.layout_title = 'The Role Gem'
 
     config.default_user_role          = nil
     config.access_denied_method       = nil

--- a/lib/the_role_api/version.rb
+++ b/lib/the_role_api/version.rb
@@ -1,1 +1,0 @@
-require_relative '../../gem_version'

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'the_string_to_slug', '~> 1.2'
+  s.add_dependency 'the_string_to_slug', '~> 1.3'
   s.add_runtime_dependency 'rails', ['>= 3.2', '< 6']
 end

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -2,7 +2,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 module TheRoleApi
-  VERSION = "3.8"
+  VERSION = "3.8.2"
 end
 
 Gem::Specification.new do |s|

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -1,6 +1,9 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "the_role_api/version"
+
+module TheRoleApi
+  VERSION = "3.8"
+end
 
 Gem::Specification.new do |s|
   s.name        = "the_role_api"

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'the_string_to_slug', '~> 1.3'
+  s.add_dependency 'the_string_to_slug', '~> 1.4'
   s.add_runtime_dependency 'rails', ['>= 3.2', '< 6']
 end

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -2,7 +2,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 module TheRoleApi
-  VERSION = "3.8.3"
+  VERSION = "3.9.0"
 end
 
 Gem::Specification.new do |s|
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'the_string_to_slug', '~> 1.4'
-  s.add_runtime_dependency 'rails', ['>= 3.2', '< 6']
+  s.add_dependency 'to_slug_param', '= 1.8'
+  s.add_runtime_dependency 'rails', ['>= 3.2', '< 7']
 end

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -2,7 +2,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 module TheRoleApi
-  VERSION = "3.8.2"
+  VERSION = "3.8.3"
 end
 
 Gem::Specification.new do |s|

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'multi_json'
   s.add_dependency 'the_string_to_slug', '~> 1.2'
-  s.add_runtime_dependency 'rails', ['>= 3.2', '< 5']
+  s.add_runtime_dependency 'rails', ['>= 3.2', '< 6']
 end


### PR DESCRIPTION
This PR upgrades the gem to version 3.9.0, compatible with rails 6.x and below(including 5.0), and reapplies our changes, in order to restore it's use in the application. 