### PR TITLE
Add case_sensitive: true to validations

### DIFF
--- a/app/models/concerns/the_role/api/role.rb
+++ b/app/models/concerns/the_role/api/role.rb
@@ -41,8 +41,8 @@ module TheRole
         attr_accessor :based_on_role
 
         has_many  :users, dependent: TheRole.config.destroy_strategy
-        validates :name,  presence: true, uniqueness: true
-        validates :title, presence: true, uniqueness: true
+        validates :name,  presence: true, uniqueness: { case_sensitive: true }
+        validates :title, presence: true, uniqueness: { case_sensitive: true }
         validates :description, presence: true
 
         private

--- a/the_role_api.gemspec
+++ b/the_role_api.gemspec
@@ -2,7 +2,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 module TheRoleApi
-  VERSION = "3.9.1"
+  VERSION = "3.9.2"
 end
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
This PR adds case_sensitive: true to validations, to comply with these Deprecation Warnings:

DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :title attribute in Role model, pass `case_sensitive: true` option explicitly to the uniqueness validator.

DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :name attribute in Role model, pass `case_sensitive: true` option explicitly to the uniqueness validator.